### PR TITLE
Fix compiler warning on 64-bit int types; dev branch

### DIFF
--- a/core/src/array/array.cc
+++ b/core/src/array/array.cc
@@ -530,7 +530,7 @@ void Array::sort_fragment_names(
       if(stripped_fragment_name[j] == '_') {
         t_str = stripped_fragment_name.substr(
                     j+1,stripped_fragment_name_size-j);
-        sscanf(t_str.c_str(), "%lld", &t); 
+        sscanf(t_str.c_str(), "%lld", (long long int*)&t); 
         t_pos_vec[i] = std::pair<int64_t, int>(t, i);
         break;
       }


### PR DESCRIPTION
Small change. This eliminates a compiler warning that `int64_t` is different from `long long int`, which should pretty much always be true.