### PR TITLE
getenv() may return NULL if a variable isn't defined - this happens for

### DIFF
--- a/core/src/misc/utils.cc
+++ b/core/src/misc/utils.cc
@@ -801,7 +801,8 @@ int read_from_file_with_mmap(
 std::string real_dir(const std::string& dir) {
   // Initialize current, home and root
   std::string current = current_dir();
-  std::string home = getenv("HOME");
+  auto env_home_ptr = getenv("HOME");
+  std::string home = env_home_ptr ? env_home_ptr : current;
   std::string root = "/";
 
   // Easy cases

--- a/core/src/storage_manager/storage_manager.cc
+++ b/core/src/storage_manager/storage_manager.cc
@@ -106,7 +106,8 @@ int StorageManager::init(const char* config_filename) {
   // Set the TileDB home directory
   tiledb_home_ = TILEDB_HOME;
   if(tiledb_home_ == "") {
-    tiledb_home_ = getenv("HOME");
+    auto env_home_ptr = getenv("HOME");
+    tiledb_home_ = env_home_ptr ? env_home_ptr : "";
     if(tiledb_home_ == "") {
       char cwd[1024];
       if(getcwd(cwd, sizeof(cwd)) != NULL) {


### PR DESCRIPTION
batch job submissions.
