### PR TITLE
Provide a way to disable file locking in POSIX fs

### DIFF
--- a/core/include/c_api/tiledb.h
+++ b/core/include/c_api/tiledb.h
@@ -118,6 +118,10 @@ typedef struct TileDB_Config {
    *      TileDB will use MPI-IO write. 
    */
   int write_method_;
+  /*
+   * Disables file locking even if the underlying storage system supports it
+   */
+  bool disable_file_locking_;
 } TileDB_Config; 
 
 

--- a/core/include/c_api/tiledb_utils.h
+++ b/core/include/c_api/tiledb_utils.h
@@ -42,7 +42,8 @@ namespace TileDBUtils {
 
 bool is_cloud_path(const std::string& path);
 
-int initialize_workspace(TileDB_CTX **ptiledb_ctx, const std::string& workspace, const bool overwrite);
+int initialize_workspace(TileDB_CTX **ptiledb_ctx, const std::string& workspace, const bool overwrite,
+    const bool disable_file_locking=false);
 
 int create_workspace(const std::string &workspace, bool replace);
 

--- a/core/include/storage_manager/storage_fs.h
+++ b/core/include/storage_manager/storage_fs.h
@@ -86,6 +86,12 @@ class StorageFS {
   virtual int close_file(const std::string& filename);
 
   virtual bool locking_support();
+
+  void set_disable_file_locking(const bool val);
+
+  bool disable_file_locking();
+ private:
+  bool disable_file_locking_;
 };
 
 #endif /* __STORAGE_FS_H__ */

--- a/core/include/storage_manager/storage_manager_config.h
+++ b/core/include/storage_manager/storage_manager_config.h
@@ -106,13 +106,15 @@ class StorageManagerConfig {
    *          TileDB will use POSIX write.
    *        - TILEDB_IO_MPI
    *          TileDB will use MPI-IO write.
+   * @param disable_file_locking disable locks in POSIX fs if set
    * @return void. 
    */
   int init(
       const char* home,
       MPI_Comm* mpi_comm,
       int read_method,
-      int write_methods); 
+      int write_methods,
+      const bool disable_file_locking);
 #else
   /**
    * Initializes the configuration parameters.
@@ -132,12 +134,14 @@ class StorageManagerConfig {
    *          TileDB will use POSIX write.
    *        - TILEDB_IO_MPI
    *          TileDB will use MPI-IO write.
+   * @param disable_file_locking disable locks in POSIX fs if set
    * @return void. 
    */
   int init(
       const char* home,
       int read_method,
-      int write_method);
+      int write_method,
+      const bool disable_file_locking);
 #endif
  
   /* ********************************* */
@@ -192,6 +196,11 @@ class StorageManagerConfig {
    *      TileDB will use MPI-IO write. 
    */
   int write_method_;
+
+  /*
+   * Disable file locking even if the backend supports it
+   */
+  bool disable_file_locking_;
 
   /** The Filesystem type associated with this configuration */
   StorageFS *fs_ = NULL;

--- a/core/src/c_api/tiledb.cc
+++ b/core/src/c_api/tiledb.cc
@@ -121,7 +121,8 @@ int tiledb_ctx_init(
         tiledb_config->mpi_comm_, 
 #endif
         tiledb_config->read_method_, 
-        tiledb_config->write_method_) == TILEDB_SMC_ERR) {
+        tiledb_config->write_method_,
+        tiledb_config->disable_file_locking_) == TILEDB_SMC_ERR) {
       strcpy(tiledb_errmsg, tiledb_smc_errmsg.c_str());
       return TILEDB_ERR;
     }

--- a/core/src/c_api/tiledb_utils.cc
+++ b/core/src/c_api/tiledb_utils.cc
@@ -42,12 +42,13 @@
 
 namespace TileDBUtils {
 
-static int setup(TileDB_CTX **ptiledb_ctx, const std::string& home) 
+static int setup(TileDB_CTX **ptiledb_ctx, const std::string& home, const bool disable_file_locking=false)
 {
   int rc;
   TileDB_Config tiledb_config;
   memset(&tiledb_config, 0, sizeof(TileDB_Config));
   tiledb_config.home_ = strdup(home.c_str());
+  tiledb_config.disable_file_locking_ = disable_file_locking;
   rc = tiledb_ctx_init(ptiledb_ctx, &tiledb_config);
   free((void *)tiledb_config.home_);
   return rc;
@@ -72,11 +73,11 @@ bool is_cloud_path(const std::string& path) {
 #define NOT_DIR -1
 #define NOT_CREATED -2
 #define UNCHANGED 1
-int initialize_workspace(TileDB_CTX **ptiledb_ctx, const std::string& workspace, const bool replace)
+int initialize_workspace(TileDB_CTX **ptiledb_ctx, const std::string& workspace, const bool replace, const bool disable_file_locking)
 {
   *ptiledb_ctx = NULL;
   int rc;
-  rc = setup(ptiledb_ctx, workspace);
+  rc = setup(ptiledb_ctx, workspace, disable_file_locking);
   if (rc) {
     return NOT_CREATED;
   }

--- a/core/src/storage_manager/storage_fs.cc
+++ b/core/src/storage_manager/storage_fs.cc
@@ -30,6 +30,9 @@
  */
 
 #include "storage_fs.h"
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
 
 /* ****************************** */
 /*        GLOBAL VARIABLES        */
@@ -46,5 +49,20 @@ int StorageFS::close_file(const std::string& filename) {
 }
 
 bool StorageFS::locking_support() {
+  return false;
+}
+
+void StorageFS::set_disable_file_locking(const bool val) {
+  disable_file_locking_ = val;
+}
+
+bool StorageFS::disable_file_locking() {
+  if(disable_file_locking_)
+    return true;
+  auto env_var = getenv("TILEDB_DISABLE_FILE_LOCKING");
+  if(env_var && (strcasecmp(env_var, "true") == 0 || strcmp(env_var, "1") == 0)) {
+    disable_file_locking_ = true;
+    return true;
+  }
   return false;
 }

--- a/core/src/storage_manager/storage_hdfs.cc
+++ b/core/src/storage_manager/storage_hdfs.cc
@@ -579,6 +579,8 @@ int HDFS::close_file(const std::string& filename) {
 static bool done_printing_consolidation_support_message = false;
 
 bool HDFS::locking_support() {
+  if(disable_file_locking())
+    return false;
   if (!done_printing_consolidation_support_message) {
     print_errmsg("No file locking support for HDFS/GCS/EMRFS paths.");
     done_printing_consolidation_support_message = true;

--- a/core/src/storage_manager/storage_manager_config.cc
+++ b/core/src/storage_manager/storage_manager_config.cc
@@ -84,7 +84,8 @@ int StorageManagerConfig::init(
     MPI_Comm* mpi_comm,
 #endif
     int read_method,
-    int write_method) {
+    int write_method,
+    const bool disable_file_locking) {
   // Initialize home
   if (strstr(home, "://")) {
      if (fs_ != NULL)
@@ -139,6 +140,8 @@ int StorageManagerConfig::init(
   if(write_method_ != TILEDB_IO_WRITE &&
      write_method_ != TILEDB_IO_MPI)
     write_method_ = TILEDB_IO_WRITE;  // Use default 
+
+  fs_->set_disable_file_locking(disable_file_locking);
 
   return TILEDB_SMC_OK;
 }

--- a/core/src/storage_manager/storage_posixfs.cc
+++ b/core/src/storage_manager/storage_posixfs.cc
@@ -483,5 +483,7 @@ int PosixFS::sync_path(const std::string& filename) {
 }
 
 bool PosixFS::locking_support() {
+  if(disable_file_locking())
+    return false;
   return true;
 }


### PR DESCRIPTION
By default, TileDB will try to lock the consolidation file. Using the
flag in the initialize_workspace() API call or setting the env variable
TILEDB_DISABLE_FILE_LOCKING will disable locking.